### PR TITLE
Add base CircleCI configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ all: api
 api:
 	@docker build -f ./Dockerfile -t $(DOCKER_IMAGE) .
 
-
 start: api
 	@docker run \
 		--detach \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # OpenAerialMap Server: API component
 
+[![Circle CI](https://circleci.com/gh/hotosm/oam-server-api/tree/master.svg?style=svg)](https://circleci.com/gh/hotosm/oam-server-api/tree/master)
+[![Docker Repository on Quay.io](https://quay.io/repository/hotosm/oam-server-api/status "Docker Repository on Quay.io")](https://quay.io/repository/hotosm/oam-server-api)
+
 The API component of OAM Server is a node `express` server that exposes API endpoints. A list of the endpoints exposed, and their functionality, is found below
 
 ### TODO: List endpoints and what they do.

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,23 @@
+machine:
+  services:
+    - docker
+
+dependencies:
+  override:
+    - docker login -e . -p ${QUAY_PASSWORD} -u ${QUAY_USER} quay.io
+
+test:
+  pre:
+    - docker build -t quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1:0:7} .
+  override:
+    - /bin/true
+
+deployment:
+  latest:
+    branch: master
+    commands:
+      - docker push quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1:0:7}
+  release:
+    tag: /[0-9]+(\.[0-9]+)*/
+    commands:
+      - docker push quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:$(git tag -l --contains HEAD)


### PR DESCRIPTION
Currently, CircleCI isn't actually running any tests (only `/bin/true`), but that can easily be updated in `circle.yml`.

More interesting is that CircleCI is setup to build and publish container images (to Quay) for all merges into `master` using the first seven characters of the Git commit as the container image's tag. Git tag pushes also produce container images, which are identified by the same version number of the tag.

See also:
- https://circleci.com/gh/hotosm/oam-server-api
- https://quay.io/repository/hotosm/oam-server-api

Related to https://github.com/hotosm/oam-server/issues/12
