### PR TITLE
Create new tag for latest; push updated latest pointer to Quay

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,12 @@ deployment:
     branch: master
     commands:
       - docker push quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1:0:7}
+      - docker tag -f quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1:0:7} ${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:latest
+      - docker push quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:latest
+
   release:
     tag: /[0-9]+(\.[0-9]+)*/
     commands:
       - docker push quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:$(git tag -l --contains HEAD)
+      - docker tag -f quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:$(git tag -l --contains HEAD) ${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:latest
+      - docker push quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:latest


### PR DESCRIPTION
After a new Docker image is pushed to Quay (tagged with either a SHA or a Git tag), create a new tag of that same reference, but name it `latest`. Then, push that tag to Quay (shouldn't require much transfer because all of the image layers should already be present at the destination).
